### PR TITLE
Add Support for Backed Enums

### DIFF
--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -31,9 +31,9 @@ trait Hookable
 	{
 		if ($name instanceof BackedEnum) {
 			if (! is_string($name->value)) {
-				throw new TypeError('Name must be either a string or StringBackedEnum');
+				throw new TypeError('Name must be either a string or an enum backed by a string');
 			}
-
+			
 			$name = $name->value;
 		}
 		

--- a/src/Hookable.php
+++ b/src/Hookable.php
@@ -2,8 +2,10 @@
 
 namespace Glhd\Hooks;
 
+use BackedEnum;
 use Closure;
 use Glhd\Hooks\Support\HookRegistry;
+use TypeError;
 
 trait Hookable
 {
@@ -25,8 +27,16 @@ trait Hookable
 		return $hooks;
 	}
 	
-	protected function callHook(string $name, ...$args): Context
+	protected function callHook(BackedEnum|string $name, ...$args): Context
 	{
+		if ($name instanceof BackedEnum) {
+			if (! is_string($name->value)) {
+				throw new TypeError('Name must be either a string or StringBackedEnum');
+			}
+
+			$name = $name->value;
+		}
+		
 		return app(HookRegistry::class)
 			->get(static::class)
 			->run($name, $args);

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -2,7 +2,9 @@
 
 namespace Glhd\Hooks;
 
+use BackedEnum;
 use Closure;
+use TypeError;
 
 class Hooks
 {
@@ -33,8 +35,16 @@ class Hooks
 		return $this;
 	}
 	
-	public function on(string $name, Closure|Hook $hook, int $priority = Hook::DEFAULT_PRIORITY): static
+	public function on(BackedEnum|string $name, Closure|Hook $hook, int $priority = Hook::DEFAULT_PRIORITY): static
 	{
+		if ($name instanceof BackedEnum) {
+			if (! is_string($name->value)) {
+				throw new TypeError('Name must be either a string or StringBackedEnum');
+			}
+			
+			$name = $name->value;
+		}
+		
 		if ($hook instanceof Closure) {
 			$hook = new Hook($hook, $priority);
 		}

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -39,7 +39,7 @@ class Hooks
 	{
 		if ($name instanceof BackedEnum) {
 			if (! is_string($name->value)) {
-				throw new TypeError('Name must be either a string or StringBackedEnum');
+				throw new TypeError('Name must be either a string or an enum backed by a string');
 			}
 			
 			$name = $name->value;

--- a/tests/HookableTest.php
+++ b/tests/HookableTest.php
@@ -8,6 +8,7 @@ use Glhd\Hooks\Hookable;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\HtmlString;
+use TypeError;
 
 class HookableTest extends TestCase
 {
@@ -66,22 +67,22 @@ class HookableTest extends TestCase
 		
 		$this->assertEquals($expected, hook_log()->all());
 	}
-
+	
 	public function test_hooks_can_be_registered_with_on_with_enum(): void
 	{
 		$hooks = HookableTestObject::hook();
-
+		
 		// We'll intentionally register our hooks out of order so that we
 		// know that registration order doesn't matter
-		$hooks->on(HookTestEnum::AfterSecond, fn() => hook_log('after second ran'));
-		$hooks->on(HookTestEnum::AfterFirst, fn() => hook_log('after first ran'));
-		$hooks->on(HookTestEnum::BeforeFirst, fn() => hook_log('before first ran'));
-		$hooks->on(HookTestEnum::BeforeSecond, fn() => hook_log('before second ran'));
-
+		$hooks->on(HookTestStringEnum::AfterSecond, fn() => hook_log('after second ran'));
+		$hooks->on(HookTestStringEnum::AfterFirst, fn() => hook_log('after first ran'));
+		$hooks->on(HookTestStringEnum::BeforeFirst, fn() => hook_log('before first ran'));
+		$hooks->on(HookTestStringEnum::BeforeSecond, fn() => hook_log('before second ran'));
+		
 		$obj = new HookableTestObject();
 		$obj->first();
 		$obj->second();
-
+		
 		$expected = [
 			'before first ran',
 			'first ran',
@@ -90,8 +91,15 @@ class HookableTest extends TestCase
 			'second ran',
 			'after second ran',
 		];
-
+		
 		$this->assertEquals($expected, hook_log()->all());
+	}
+	
+	public function test_int_backed_enums_throw_an_exception(): void
+	{
+		$this->expectException(TypeError::class);
+		
+		HookableTestObject::hook()->on(HookTestIntEnum::One, fn() => null);
 	}
 	
 	public function test_an_object_can_have_a_default_hook(): void
@@ -187,12 +195,17 @@ class HookableTest extends TestCase
 	}
 }
 
-enum HookTestEnum: string
+enum HookTestStringEnum: string
 {
 	case BeforeFirst = 'beforeFirst';
 	case AfterFirst = 'afterFirst';
 	case BeforeSecond = 'beforeSecond';
 	case AfterSecond = 'afterSecond';
+}
+
+enum HookTestIntEnum: int
+{
+	case One = 1;
 }
 
 class HookableTestObject

--- a/tests/HookableTest.php
+++ b/tests/HookableTest.php
@@ -66,6 +66,33 @@ class HookableTest extends TestCase
 		
 		$this->assertEquals($expected, hook_log()->all());
 	}
+
+	public function test_hooks_can_be_registered_with_on_with_enum(): void
+	{
+		$hooks = HookableTestObject::hook();
+
+		// We'll intentionally register our hooks out of order so that we
+		// know that registration order doesn't matter
+		$hooks->on(HookTestEnum::AfterSecond, fn() => hook_log('after second ran'));
+		$hooks->on(HookTestEnum::AfterFirst, fn() => hook_log('after first ran'));
+		$hooks->on(HookTestEnum::BeforeFirst, fn() => hook_log('before first ran'));
+		$hooks->on(HookTestEnum::BeforeSecond, fn() => hook_log('before second ran'));
+
+		$obj = new HookableTestObject();
+		$obj->first();
+		$obj->second();
+
+		$expected = [
+			'before first ran',
+			'first ran',
+			'after first ran',
+			'before second ran',
+			'second ran',
+			'after second ran',
+		];
+
+		$this->assertEquals($expected, hook_log()->all());
+	}
 	
 	public function test_an_object_can_have_a_default_hook(): void
 	{
@@ -158,6 +185,14 @@ class HookableTest extends TestCase
 			'Hello Daniel!',
 		]);
 	}
+}
+
+enum HookTestEnum: string
+{
+	case BeforeFirst = 'beforeFirst';
+	case AfterFirst = 'afterFirst';
+	case BeforeSecond = 'beforeSecond';
+	case AfterSecond = 'afterSecond';
 }
 
 class HookableTestObject


### PR DESCRIPTION
This PR adds support for `BackedEnum`'s in the `callHook` and `on` methods.

If there are any changes you need me to make, please let me know.